### PR TITLE
Working with Tensorflow r0.11 and Google's latest models

### DIFF
--- a/litterbox/example_predict.py
+++ b/litterbox/example_predict.py
@@ -22,7 +22,7 @@ from models import ModelInception, ModelGoogle
 
 
 class ExampleData(DatasetFile):
-    """StateFarm data set."""
+    # Example dataset for feeding folder of images into model
 
     def __init__(self, subset):
         super(ExampleData, self).__init__('Example', subset)

--- a/litterbox/fabric/exec_train.py
+++ b/litterbox/fabric/exec_train.py
@@ -116,11 +116,11 @@ def _add_tower_loss(images, labels, num_classes, model, scope):
     for l in tower_losses + [total_loss]:
         # Remove 'tower_[0-9]/' from the name in case this is a multi-GPU training
         # session. This helps the clarity of presentation on TensorBoard.
-        loss_name = re.sub('%s_[0-9]*/' % model.TOWER_NAME, '', l.op.name)
+        loss_name = model.strip_common_scope(l.op.name)
         # Name each loss as '(raw)' and name the moving average version of the loss
         # as the original loss name.
-        tf.scalar_summary(loss_name + ' (raw)', l)
-        tf.scalar_summary(loss_name, loss_averages.average(l))
+        tf.scalar_summary('losses/' + loss_name + ' (raw)', l)
+        tf.scalar_summary('losses/' + loss_name, loss_averages.average(l))
     with tf.control_dependencies([loss_averages_op]):
         total_loss = tf.identity(total_loss)
         output_loss = tf.identity(tower_losses[0])
@@ -253,7 +253,7 @@ def _build_train_graph(feed, model):
 
     # Add histograms for trainable variables.
     for var in tf.trainable_variables():
-        summaries.append(tf.histogram_summary(var.op.name, var))
+        summaries.append(tf.histogram_summary(model.strip_common_scope(var.op.name), var))
 
     if FLAGS.moving_average_decay:
         moving_average_variables = (tf.trainable_variables() + tf.moving_average_variables())

--- a/litterbox/models/inception/model_inception.py
+++ b/litterbox/models/inception/model_inception.py
@@ -28,7 +28,7 @@ class ModelInception(fabric.Model):
     # If a model is trained using multiple GPUs, prefix all Op names with tower_name
     # to differentiate the operations. Note that this prefix is removed from the
     # names of the summaries when visualizing a model.
-    TOWER_NAME = 'tower'
+    TOWER_PREFIX = 'tower'
 
     # Batch normalization. Constant governing the exponential moving average of
     # the 'global' mean and variance for all activations.


### PR DESCRIPTION
… model histogram scopes.
- Put most regex code for stripping extra scope prefix for summaries in one location
- Fix the name collision with some google models that create multiple endpoints resolving to same entity
- Multi-gpu operating needs to be re-tested with these scoping changes!
